### PR TITLE
chore: upgrade actions/checkout to v7

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v7
     - name: Cache Maven dependencies
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
Upgrades stale actions/checkout@v1 to v7 in .github/workflows/maven.yml.

Tracking: https://github.com/katalon-studio/platform-foundation/issues/1139